### PR TITLE
Remove marker widgets after transformation

### DIFF
--- a/lib/gist/Gist.dart
+++ b/lib/gist/Gist.dart
@@ -23,11 +23,18 @@ class MarkerGenerator {
   void addOverlay(BuildContext context) {
     OverlayState overlayState = Overlay.of(context);
 
-    OverlayEntry entry = OverlayEntry(
+    OverlayEntry entry;
+    entry = OverlayEntry(
         builder: (context) {
           return _MarkerHelper(
             markerWidgets: markerWidgets,
-            callback: callback,
+            callback: (List<Uint8List> bitmapList) {
+                // Given callback function
+                callback.call(bitmapList);
+                
+                // Remove marker widget stack from Overlay when finished
+                entry.remove();
+              },
           );
         },
         maintainState: true);
@@ -59,7 +66,7 @@ class _MarkerHelper extends StatefulWidget {
 }
 
 class _MarkerHelperState extends State<_MarkerHelper> with AfterLayoutMixin {
-  List<GlobalKey> globalKeys = List<GlobalKey>();
+  List<GlobalKey> globalKeys = [];
 
   @override
   void afterFirstLayout(BuildContext context) {


### PR DESCRIPTION
Removal of the marker widgets from the `Overlay` after transformation is necessary to reduce performance issues when having more than a couple of markers.

Without the removal **the whole app starts to lag** because the marker widgets, which can be hundreds, are still rendered on top of every screen.
It seems like they're also added more than one time, when not removed from the Overlay.